### PR TITLE
Reimplemented support for @InheritableMustCall to use the proper hooks

### DIFF
--- a/framework/src/main/java/org/checkerframework/framework/type/QualifierUpperBounds.java
+++ b/framework/src/main/java/org/checkerframework/framework/type/QualifierUpperBounds.java
@@ -6,7 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.Element;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -105,8 +105,7 @@ public class QualifierUpperBounds {
     String qname;
     if (type.getKind() == TypeKind.DECLARED) {
       DeclaredType declaredType = (DeclaredType) type;
-      bounds.addAll(
-          atypeFactory.fromElement((TypeElement) declaredType.asElement()).getAnnotations());
+      bounds.addAll(getAnnotationFromElement(declaredType.asElement()));
       qname = TypesUtils.getQualifiedName(declaredType).toString();
     } else if (type.getKind().isPrimitive()) {
       qname = type.toString();
@@ -128,6 +127,17 @@ public class QualifierUpperBounds {
 
     addMissingAnnotations(bounds, atypeFactory.getDefaultTypeDeclarationBounds());
     return bounds;
+  }
+
+  /**
+   * Returns the explicit annotations on the element. Subclass can override this behavior to add
+   * annotations.
+   *
+   * @param element element whose annotations to return
+   * @return the explicit annotations on the element
+   */
+  protected Set<AnnotationMirror> getAnnotationFromElement(Element element) {
+    return atypeFactory.fromElement(element).getAnnotations();
   }
 
   /**


### PR DESCRIPTION
Rather than overriding  (and violating the semantics of) fromElement.

I'll make a pull request to typetools with the change to framework/src/main/java/org/checkerframework/framework/type/QualifierUpperBounds.java.