### PR TITLE
Permit WPI to infer types inside the scope of a warning suppression

### DIFF
--- a/checker/tests/ainfer-testchecker/non-annotated/ExpectedErrors.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/ExpectedErrors.java
@@ -144,57 +144,6 @@ public class ExpectedErrors {
     @AinferBottom Object bot = o;
   }
 
-  public class SuppressWarningsTest {
-    // Tests that whole-program inference in a @SuppressWarnings block is ignored.
-    private int i;
-    private int i2;
-
-    @SuppressWarnings("all")
-    public void suppressWarningsTest() {
-      i = (@Sibling1 int) 0;
-      i2 = getSibling1();
-    }
-
-    public void suppressWarningsTest2() {
-      SuppressWarningsInner.i = (@Sibling1 int) 0;
-      SuppressWarningsInner.i2 = getSibling1();
-    }
-
-    public void suppressWarningsValidation() {
-      // :: warning: (argument)
-      expectsSibling1(i);
-      // :: warning: (argument)
-      expectsSibling1(i2);
-      // :: warning: (argument)
-      expectsSibling1(SuppressWarningsInner.i);
-      // :: warning: (argument)
-      expectsSibling1(SuppressWarningsInner.i2);
-      // :: warning: (argument)
-      expectsSibling1(suppressWarningsMethodReturn());
-
-      suppressWarningsMethodParams(getSibling1());
-    }
-
-    @SuppressWarnings("all")
-    public int suppressWarningsMethodReturn() {
-      return getSibling1();
-    }
-
-    // It is problematic to automatically test whole-program inference for method params when
-    // suppressing warnings.
-    // Since we must use @SuppressWarnings() for the method, we won't be able to catch any error
-    // inside the method body.  Verified manually that in the "annotated" folder param's type wasn't
-    // updated.
-    @SuppressWarnings("all")
-    public void suppressWarningsMethodParams(int param) {}
-  }
-
-  @SuppressWarnings("all")
-  static class SuppressWarningsInner {
-    public static int i;
-    public static int i2;
-  }
-
   class NullTest {
     // The default type for fields is @DefaultType.
     private String privateField;

--- a/checker/tests/ainfer-testchecker/non-annotated/OverriddenMethodsTest.java
+++ b/checker/tests/ainfer-testchecker/non-annotated/OverriddenMethodsTest.java
@@ -37,18 +37,6 @@ public class OverriddenMethodsTest {
       @Sibling2 Object o = obj;
     }
 
-    @SuppressWarnings("all")
-    @Override
-    public void barz(Object obj) {}
-
-    public void callbarz(Object obj) {
-      // If the @SuppressWarnings("all") on the overridden version of barz above is not
-      // respected, and the annotations on the receiver and parameter of barz are
-      // inferred, then the following call to barz will result in a method.invocation
-      // and an argument type checking errors.
-      barz(obj);
-    }
-
     public void callqux(@Sibling1 Object obj1, @Sibling2 Object obj2) {
       qux(obj1, obj2);
     }

--- a/checker/tests/ainfer-testchecker/non-annotated/README.md
+++ b/checker/tests/ainfer-testchecker/non-annotated/README.md
@@ -1,0 +1,21 @@
+The files in this directory are tested while using the -Ainfer option.
+For this reason, each of these files is typechecked twice: once to infer
+annotations (the "Generate" phase), and a second time
+to ensure no more errors are issued once whole-program inference has been
+run (the "Validate" phase). Between these two phases, the files
+are copied to the ../annotated/ directory (i.e., the files in that
+directory are the inputs to the "Validate" phase) and all expected errors and
+warnings are removed. The ../inference-output/ contains the produced
+annotation files (i.e., the .jaif, .astub, or .ajava files).
+
+Because all the annotation files are stored in the same directory, there
+are two requirements for test inputs that are typechecked as part of
+these tests (that is, the test files in this directory and all all-systems
+tests):
+* the fully-qualified name of each test class must be unique, because annotation
+  files use a naming scheme based on the fully-qualified name of the class. This
+  means, for example, that this directory cannot contain any test files with the
+  same name as any all-systems test.
+* every class must either be or be contained by a class whose name matches the name
+  of the file containing the class. This requirement is caused by the need to locate
+  programmatically the annotation files generated from a particular test.

--- a/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
+++ b/framework/src/main/java/org/checkerframework/common/wholeprograminference/WholeProgramInferenceImplementation.java
@@ -841,6 +841,10 @@ public class WholeProgramInferenceImplementation<T> implements WholeProgramInfer
 
     switch (sourceCodeATM.getKind()) {
       case TYPEVAR:
+        if (!(ajavaATM instanceof AnnotatedTypeVariable)) {
+          assert TypesUtils.isObject(ajavaATM.getUnderlyingType());
+          break;
+        }
         updateAtmWithLub(
             ((AnnotatedTypeVariable) sourceCodeATM).getLowerBound(),
             ((AnnotatedTypeVariable) ajavaATM).getLowerBound());


### PR DESCRIPTION
According to @msridhar and @Nargeshdb's profiling, this should make WPI ~3% faster, for almost no cost. The semantics are slightly different: before, WPI would never infer an annotation within the scope of a relevant warning suppression (because that would then be ignored). It turns out that the cost of checking for the suppress warnings annotation is expensive (because of the need to check TreePaths in other compilation units), so it's cheaper to just ignore it.

This PR is into my branch with the all-systems tests enabled for WPI.